### PR TITLE
Fix possible merge error in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
           }
         }
       }
-    }
+    },
     "ansi-escapes": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",


### PR DESCRIPTION
Hi Jan from Depfu here. I noticed an error in our update process and it looks like some process or a manual merge error (I did not investigate) removed a crucial comma from the package-lock.json which throws a wrench into our gears.

This fixes the JSON validation error (so that the JSON can be parsed again) but I am not sure if this makes the package-lock.json actually valid for npm.